### PR TITLE
로깅 AOP 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -62,6 +62,10 @@ dependencies {
     compile 'org.springframework:spring-webmvc'
     compile 'org.springframework:spring-jdbc'
 
+    // Spring AOP Dependencies
+    compile 'org.aspectj:aspectjrt'
+    compile 'org.aspectj:aspectjweaver'
+
     // Spring Security Dependencies
     testCompile 'org.springframework.security:spring-security-test'
     compile 'org.springframework.security:spring-security-web'

--- a/src/main/java/sms/aop/LoggingAspect.java
+++ b/src/main/java/sms/aop/LoggingAspect.java
@@ -1,0 +1,37 @@
+package sms.aop;
+
+import org.aspectj.lang.JoinPoint;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Before;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import javax.servlet.http.HttpServletRequest;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+@Aspect // not @Component => not component-scan
+public class LoggingAspect {
+    private static final Logger logger = LoggerFactory.getLogger(LoggingAspect.class);
+
+    @Autowired
+    private HttpServletRequest request;
+
+    @Before("@annotation(org.springframework.web.bind.annotation.RequestMapping)")
+    public void loggingRequestMapping(JoinPoint joinPoint) {
+        String mappingMethod = parseMethodName(joinPoint.toString());
+        String requestMappingInfo = String.format("Request URL Mapping - [%S][%s] ===> [%s]",
+                request.getMethod(), request.getRequestURI(), mappingMethod);
+
+        logger.info(requestMappingInfo);
+    }
+
+    // ex. "execution(String foo.bar.method(..))" ==> "foo.bar.method()"
+    private String parseMethodName(String joinPoint) {
+        Pattern pattern = Pattern.compile("^.+ ([\\w.]+)\\(.*");
+        Matcher matcher = pattern.matcher(joinPoint);
+
+        return matcher.find() ? matcher.group(1) + "()" : "Method Name Parsing Error";
+    }
+}

--- a/src/main/java/sms/aop/LoggingAspect.java
+++ b/src/main/java/sms/aop/LoggingAspect.java
@@ -20,7 +20,7 @@ public class LoggingAspect {
 
     @Before("@annotation(org.springframework.web.bind.annotation.RequestMapping)")
     public void loggingRequestMapping(JoinPoint joinPoint) {
-        String mappingMethod = parseMethodName(joinPoint.toString());
+        String mappingMethod = parseMethodName(joinPoint);
         String requestMappingInfo = String.format("Request URL Mapping - [%S][%s] ===> [%s]",
                 request.getMethod(), request.getRequestURI(), mappingMethod);
 
@@ -28,10 +28,13 @@ public class LoggingAspect {
     }
 
     // ex. "execution(String foo.bar.method(..))" ==> "foo.bar.method()"
-    private String parseMethodName(String joinPoint) {
-        Pattern pattern = Pattern.compile("^.+ ([\\w.]+)\\(.*");
-        Matcher matcher = pattern.matcher(joinPoint);
+    private String parseMethodName(JoinPoint joinPoint) {
+        String errorMessage = "Method Name Parsing Error";
+        if (joinPoint == null) return errorMessage;
 
-        return matcher.find() ? matcher.group(1) + "()" : "Method Name Parsing Error";
+        Pattern pattern = Pattern.compile("^.+ ([\\w.]+)\\(.*");
+        Matcher matcher = pattern.matcher(joinPoint.toString());
+
+        return matcher.find() ? matcher.group(1) + "()" : errorMessage;
     }
 }

--- a/src/main/java/sms/sample/SampleController.java
+++ b/src/main/java/sms/sample/SampleController.java
@@ -11,7 +11,7 @@ import org.springframework.web.bind.annotation.RequestMethod;
 public class SampleController {
 
     @Autowired
-    SqlSession sqlSession;
+    private SqlSession sqlSession;
 
     @RequestMapping(value = "/", method = RequestMethod.GET)
     public String samplePage(Model model) {

--- a/src/main/webapp/WEB-INF/spring-config/web-aop-context.xml
+++ b/src/main/webapp/WEB-INF/spring-config/web-aop-context.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:aop="http://www.springframework.org/schema/aop"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+          http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop.xsd">
+
+    <aop:aspectj-autoproxy />
+
+    <bean id="loggingAspect" class="sms.aop.LoggingAspect" />
+</beans>

--- a/src/main/webapp/WEB-INF/spring-config/web-context.xml
+++ b/src/main/webapp/WEB-INF/spring-config/web-context.xml
@@ -7,8 +7,9 @@
         http://www.springframework.org/schema/mvc http://www.springframework.org/schema/mvc/spring-mvc.xsd
         http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd">
 
+	<import resource="web-aop-context.xml" />
+
     <mvc:annotation-driven />
-    
 	<context:component-scan base-package="sms" use-default-filters="false">
 		<context:include-filter type="annotation" expression="org.springframework.stereotype.Controller"/>
 	</context:component-scan>

--- a/src/test/java/sms/aop/LoggingAspectTest.java
+++ b/src/test/java/sms/aop/LoggingAspectTest.java
@@ -1,0 +1,60 @@
+package sms.aop;
+
+import org.aspectj.lang.JoinPoint;
+import org.aspectj.lang.Signature;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.slf4j.Logger;
+import org.springframework.context.annotation.Configuration;
+
+import javax.servlet.http.HttpServletRequest;
+
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+@Configuration
+public class LoggingAspectTest {
+
+    @Mock
+    private Logger mockLogger;
+    @Mock
+    private JoinPoint mockJoinPoint;
+    @Mock
+    private HttpServletRequest mockRequest;
+
+    private LoggingAspect loggingAspect;
+
+    @Before
+    public void setUp() throws Exception {
+        loggingAspect = new LoggingAspect(mockLogger, mockRequest);
+    }
+
+    @Test
+    public void WhenInvokeRequestMappingAdviceDirectlyThenLogging() throws Exception {
+        expectRequestAction("get", "/some-resource");
+        expectJoinPointAction("foo.bar.SomeClass", "someMethod");
+        String expectedMessage =
+                "Request URL Mapping - [GET][/some-resource] ===> [foo.bar.SomeClass.someMethod()]";
+
+        loggingAspect.loggingRequestMapping(mockJoinPoint);
+
+        verify(mockLogger).info(expectedMessage);
+    }
+
+    private void expectRequestAction(String requestMethod, String requestURI) {
+        when(mockRequest.getMethod()).thenReturn(requestMethod);
+        when(mockRequest.getRequestURI()).thenReturn(requestURI);
+    }
+
+    private void expectJoinPointAction(String signatureTypeName, String signatureName) {
+        final Signature mockSignature = Mockito.mock(Signature.class);
+        when(mockJoinPoint.getSignature()).thenReturn(mockSignature);
+        when(mockSignature.getDeclaringTypeName()).thenReturn(signatureTypeName);
+        when(mockSignature.getName()).thenReturn(signatureName);
+    }
+}


### PR DESCRIPTION
### 로깅을 위한 스프링 AOP 설정
- 웹에서 특정 URL 요청시 매핑된 컨트롤러 메서드명이 출력되는 로그 설정을 하였습니다.
- 참고: 프로젝트에 2개의 컨텍스트(root-context, web-context)가 있는데 aop는 컨택스트별로 적용 되기 때문에 
           컨트롤러 빈에 로깅을 적용하기 위해서 web-context에 aop설정을 하였습니다.
            (web-context는 root-context의 자식 컨텍스트이기 때문에 root-context가 소유한 빈에  대해서도 자동적으로 aop 적용됩니다. 반대로, root-context에만 aop 적용 시 web-context가 관리하는 빈에 대해서 별도의 설정 없이는 aop를 적용할 수 없습니다.)